### PR TITLE
Fix audio clicks with larger IO buffer

### DIFF
--- a/Packages/MicrophonePitchDetector/Sources/MicrophonePitchDetector/AudioEngine.swift
+++ b/Packages/MicrophonePitchDetector/Sources/MicrophonePitchDetector/AudioEngine.swift
@@ -56,7 +56,11 @@ final class AudioEngine {
     /// Configures the audio session
     func configureSession() throws {
         let session = AVAudioSession.sharedInstance()
-        let bufferDuration = 7 / AVAudioFormat.stereo.sampleRate
+        // Use a slightly larger IO buffer to avoid clicks when other audio
+        // engines (like the function generator) are active. 256 frames at the
+        // current sample rate gives a stable ~5–6 ms buffer on most devices.
+        let preferredFrames: Double = 256
+        let bufferDuration = preferredFrames / AVAudioFormat.stereo.sampleRate
 #if !os(watchOS)
         try session.setPreferredIOBufferDuration(bufferDuration)
         try session.setCategory(.playAndRecord, options: [.defaultToSpeaker, .mixWithOthers])


### PR DESCRIPTION
## Summary
- bump IO buffer size to ~256 frames in AudioEngine to reduce clicks when running function generator and tuner simultaneously

## Testing
- `swift test -l` *(fails: unable to fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68647ac7ea408330906416ea51529042