### PR TITLE
Central audio engine

### DIFF
--- a/Chromatic/ChromaticApp.swift
+++ b/Chromatic/ChromaticApp.swift
@@ -2,11 +2,25 @@
 // Your @main entry, now hosting both tuner and player
 import SwiftUI
 import MicrophonePitchDetector
+import AVFoundation
 
 @main
 struct ChromaticApp: App {
     @StateObject private var audioPlayer = AudioPlayer()
-    @StateObject private var pitchDetector = MicrophonePitchDetector()
+    private let sharedEngine = AVAudioEngine()
+    @StateObject private var pitchDetector: MicrophonePitchDetector
+    private let functionGenerator: FunctionGeneratorEngine
+    private let mixerEngine: MixerEngine
+
+    init() {
+        // Configure MicrophonePitchDetector with the shared engine
+        let detectorEngine = AudioEngine(avAudioEngine: sharedEngine)
+        _pitchDetector = StateObject(wrappedValue: MicrophonePitchDetector(engine: detectorEngine))
+
+        // Other engines attach to the same AVAudioEngine
+        functionGenerator = FunctionGeneratorEngine(engine: sharedEngine)
+        mixerEngine = MixerEngine(engine: sharedEngine)
+    }
     @AppStorage("modifierPreference") private var modifierPreference = ModifierPreference.preferSharps
     @AppStorage("selectedTransposition") private var selectedTransposition = 0
 
@@ -16,14 +30,33 @@ struct ChromaticApp: App {
                 TunerScreen(pitchDetector: pitchDetector, modifierPreference: $modifierPreference, selectedTransposition: $selectedTransposition).tabItem { Label("Tuner", systemImage: "tuningfork") }
                 PlayerView(audioPlayer: audioPlayer, pitchDetector: pitchDetector, modifierPreference: $modifierPreference, selectedTransposition: $selectedTransposition)
                     .tabItem { Label("Player", systemImage: "music.note") }
-                FunctionGeneratorView(engine: FunctionGeneratorEngine())
+                FunctionGeneratorView(engine: functionGenerator)
                     .tabItem { Label("Func Gen", systemImage: "waveform.path") }
             }
             .onAppear {
                 #if os(iOS)
                 UIApplication.shared.isIdleTimerDisabled = true
                 #endif
+                configureAudioSession()
             }
+        }
+    }
+
+    private func configureAudioSession() {
+#if !os(macOS)
+        let session = AVAudioSession.sharedInstance()
+        let preferredFrames: Double = 256
+        let bufferDuration = preferredFrames / 44_100
+#if !os(watchOS)
+        try? session.setPreferredIOBufferDuration(bufferDuration)
+        try? session.setCategory(.playAndRecord, options: [.defaultToSpeaker, .mixWithOthers])
+#endif
+        try? session.setActive(true)
+#endif
+        do {
+            try sharedEngine.start()
+        } catch {
+            print("❌ Shared engine failed to start: \(error)")
         }
     }
 }

--- a/Chromatic/Models/FunctionGeneratorEngine.swift
+++ b/Chromatic/Models/FunctionGeneratorEngine.swift
@@ -147,9 +147,10 @@ class Channel: ObservableObject, Identifiable { // Conforms to ObservableObject
 /// Engine managing four oscillators
 class FunctionGeneratorEngine: ObservableObject {
     @Published var channels: [Channel] = []
-    private let engine = AVAudioEngine()
+    private let engine: AVAudioEngine
 
-    init(channelsCount: Int = 4) {
+    init(engine: AVAudioEngine, channelsCount: Int = 4) {
+        self.engine = engine
         let sampleRate = engine.outputNode.outputFormat(forBus: 0).sampleRate
         let format = AVAudioFormat(standardFormatWithSampleRate: sampleRate, channels: 1)!
 
@@ -160,11 +161,6 @@ class FunctionGeneratorEngine: ObservableObject {
             engine.connect(channel.sourceNode, to: engine.mainMixerNode, format: format)
         }
 
-        do {
-            try engine.start()
-        } catch {
-            print("❌ Audio engine failed to start: \(error)")
-        }
     }
 
     func setWaveform(_ wf: Waveform, for index: Int) {

--- a/Chromatic/Models/MixerEngine.swift
+++ b/Chromatic/Models/MixerEngine.swift
@@ -16,10 +16,11 @@ class MixerEngine: ObservableObject {
     }
 
     @Published var tracks: [Track] = []
-    private let engine = AVAudioEngine()
+    private let engine: AVAudioEngine
     private let mainMixer = AVAudioMixerNode()
 
-    init(numberOfTracks: Int = 4) {
+    init(engine: AVAudioEngine, numberOfTracks: Int = 4) {
+        self.engine = engine
         // Attach main mixer
         engine.attach(mainMixer)
         engine.connect(mainMixer, to: engine.mainMixerNode, format: nil)
@@ -32,11 +33,6 @@ class MixerEngine: ObservableObject {
             tracks.append(Track(playerNode: node))
         }
 
-        do {
-            try engine.start()
-        } catch {
-            print("❌ Mixer engine start error: \(error)")
-        }
     }
 
     /// Load an audio file into a track

--- a/Chromatic/TunerScreen.swift
+++ b/Chromatic/TunerScreen.swift
@@ -31,7 +31,7 @@ struct TunerScreen: View {
 struct TunerScreen_Previews: PreviewProvider {
     static var previews: some View {
         TunerScreen(
-            pitchDetector: MicrophonePitchDetector(),
+            pitchDetector: MicrophonePitchDetector(engine: AudioEngine()),
             modifierPreference: .constant(.preferSharps),
             selectedTransposition: .constant(0)
         )

--- a/Chromatic/Views/FunctionGeneratorView.swift
+++ b/Chromatic/Views/FunctionGeneratorView.swift
@@ -9,7 +9,7 @@
 import SwiftUI
 
 struct FunctionGeneratorView: View {
-    @StateObject var engine = FunctionGeneratorEngine() // Changed to @StateObject
+    @ObservedObject var engine: FunctionGeneratorEngine
 
     var body: some View {
         ScrollView {
@@ -32,6 +32,6 @@ struct FunctionGeneratorView: View {
 
 struct FunctionGeneratorView_Previews: PreviewProvider {
     static var previews: some View {
-        FunctionGeneratorView()
+        FunctionGeneratorView(engine: FunctionGeneratorEngine(engine: AVAudioEngine()))
     }
 }

--- a/Chromatic/Views/MixerView.swift
+++ b/Chromatic/Views/MixerView.swift
@@ -12,7 +12,7 @@
 import SwiftUI
 
 struct MixerView: View {
-    @ObservedObject var mixer = MixerEngine()
+    @ObservedObject var mixer: MixerEngine
     @State private var filePickerIndex: Int? = nil
 
     var body: some View {
@@ -69,6 +69,6 @@ struct MixerView: View {
 
 struct MixerView_Previews: PreviewProvider {
     static var previews: some View {
-        MixerView()
+        MixerView(mixer: MixerEngine(engine: AVAudioEngine()))
     }
 }

--- a/Chromatic/Views/PlayerView.swift
+++ b/Chromatic/Views/PlayerView.swift
@@ -80,7 +80,7 @@ struct PlayerView_Previews: PreviewProvider {
     static var previews: some View {
         PlayerView(
             audioPlayer: AudioPlayer(),
-            pitchDetector: MicrophonePitchDetector(),
+            pitchDetector: MicrophonePitchDetector(engine: AudioEngine()),
             modifierPreference: .constant(.preferSharps),
             selectedTransposition: .constant(0)
         )

--- a/Packages/MicrophonePitchDetector/Sources/MicrophonePitchDetector/AudioEngine.swift
+++ b/Packages/MicrophonePitchDetector/Sources/MicrophonePitchDetector/AudioEngine.swift
@@ -20,7 +20,7 @@ extension AVAudioMixerNode {
 /// AudioKit's wrapper for AVAudioEngine
 final class AudioEngine {
     /// Internal AVAudioEngine
-    private let avEngine = AVAudioEngine()
+    let avEngine: AVAudioEngine
 
     /// Input node mixer
     private final class Input: Mixer {
@@ -44,30 +44,16 @@ final class AudioEngine {
         return _input.auMixer
     }
 
-    /// Empty initializer
-    init() {}
+    /// Initialize with an optional external AVAudioEngine
+    init(avAudioEngine: AVAudioEngine = AVAudioEngine()) {
+        self.avEngine = avAudioEngine
+    }
 
     /// Start the engine
     func start() throws {
         try avEngine.start()
     }
 
-#if !os(macOS)
-    /// Configures the audio session
-    func configureSession() throws {
-        let session = AVAudioSession.sharedInstance()
-        // Use a slightly larger IO buffer to avoid clicks when other audio
-        // engines (like the function generator) are active. 256 frames at the
-        // current sample rate gives a stable ~5–6 ms buffer on most devices.
-        let preferredFrames: Double = 256
-        let bufferDuration = preferredFrames / AVAudioFormat.stereo.sampleRate
-#if !os(watchOS)
-        try session.setPreferredIOBufferDuration(bufferDuration)
-        try session.setCategory(.playAndRecord, options: [.defaultToSpeaker, .mixWithOthers])
-#endif
-        try session.setActive(true)
-    }
-#endif
 
     // MARK: - Private
 

--- a/Packages/MicrophonePitchDetector/Sources/MicrophonePitchDetector/MicrophonePitchDetector.swift
+++ b/Packages/MicrophonePitchDetector/Sources/MicrophonePitchDetector/MicrophonePitchDetector.swift
@@ -5,7 +5,7 @@ import WatchKit
 #endif
 
 public final class MicrophonePitchDetector: ObservableObject {
-    private let engine = AudioEngine()
+    private let engine: AudioEngine
     private var isRunning = false
     private var tracker: PitchTap!
 
@@ -14,7 +14,9 @@ public final class MicrophonePitchDetector: ObservableObject {
     @Published public var didReceiveAudio = false
     @Published public var showMicrophoneAccessAlert = false
 
-    public init() {}
+    public init(engine: AudioEngine = AudioEngine()) {
+        self.engine = engine
+    }
 
     @MainActor
     public func activate() async throws {
@@ -29,9 +31,6 @@ public final class MicrophonePitchDetector: ObservableObject {
     }
 
     private func setUpPitchTracking() async throws {
-#if !os(macOS)
-        try engine.configureSession()
-#endif
         tracker = PitchTap(engine.inputMixer, handler: { pitch, amplitude in
             Task { @MainActor in
                 self.pitch = pitch


### PR DESCRIPTION
## Summary
- establish a shared `AVAudioEngine` in `ChromaticApp`
- inject the shared engine into the pitch detector, function generator and mixer
- allow MicrophonePitchDetector and its `AudioEngine` wrapper to accept external engines
- remove redundant audio session setup from the detector

## Testing
- `swift test --parallel` *(fails: could not fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68647dc2cea4833092396cc81045fa38