### PR TITLE
Add Profiles tab with shared profile manager

### DIFF
--- a/Chromatic/ChromaticApp.swift
+++ b/Chromatic/ChromaticApp.swift
@@ -9,6 +9,7 @@ struct ChromaticApp: App {
     @StateObject private var audioPlayer = AudioPlayer()
     @StateObject private var pitchDetector = MicrophonePitchDetector()
     @StateObject private var sessionStore = SessionStore() // Initialize SessionStore
+    @StateObject private var profileManager = UserProfileManager()
     @AppStorage("modifierPreference") private var modifierPreference = ModifierPreference.preferSharps
     @AppStorage("selectedTransposition") private var selectedTransposition = 0
     
@@ -23,6 +24,9 @@ struct ChromaticApp: App {
                 PlayerView(audioPlayer: audioPlayer, pitchDetector: pitchDetector, modifierPreference: $modifierPreference, selectedTransposition: $selectedTransposition)
                     .tabItem { Label("Player", systemImage: "music.note") }
 
+                ProfilesTabView()
+                    .tabItem { Label("Profiles", systemImage: "person.crop.circle") }
+
                 SavedSessionsView() // Add SavedSessionsView as a new tab
                     .tabItem { Label("Sessions", systemImage: "list.bullet.rectangle") }
 
@@ -31,6 +35,7 @@ struct ChromaticApp: App {
 //                SpectogramView().tabItem { Label("Spectrum", systemImage: "waveform") }
             }
             .environmentObject(sessionStore) // Inject SessionStore into the environment
+            .environmentObject(profileManager)
             .preferredColorScheme(.dark)
             .onAppear {
                 #if os(iOS)

--- a/Chromatic/TunerScreen.swift
+++ b/Chromatic/TunerScreen.swift
@@ -65,5 +65,6 @@ struct TunerScreen_Previews: PreviewProvider {
             modifierPreference: .constant(.preferSharps),
             selectedTransposition: .constant(0)
         )
+        .environmentObject(UserProfileManager())
     }
 }

--- a/Chromatic/Views/ProfilesTabView.swift
+++ b/Chromatic/Views/ProfilesTabView.swift
@@ -1,0 +1,94 @@
+import SwiftUI
+
+struct ProfilesTabView: View {
+    @EnvironmentObject var profileManager: UserProfileManager
+    @State private var showingCreateProfileAlert = false
+    @State private var newProfileName: String = ""
+    @State private var newProfileF0: Double = 77.78
+    @State private var profileToEdit: UserProfile? = nil
+
+    var body: some View {
+        NavigationView {
+            List {
+                ForEach(profileManager.profiles) { profile in
+                    HStack {
+                        VStack(alignment: .leading) {
+                            Text(profile.name)
+                                .font(.headline)
+                            Text("f₀: \(profile.f0, specifier: "%.2f") Hz")
+                                .font(.subheadline)
+                                .foregroundColor(.gray)
+                        }
+                        Spacer()
+                        Button {
+                            profileToEdit = profile
+                        } label: {
+                            Image(systemName: "pencil.circle.fill")
+                                .foregroundColor(.accentColor)
+                        }
+                        .buttonStyle(BorderlessButtonStyle())
+                    }
+                    .contentShape(Rectangle())
+                    .onTapGesture {
+                        profileManager.selectProfile(profile)
+                    }
+                }
+                .onDelete(perform: deleteProfile)
+            }
+            .navigationTitle("Profiles")
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button {
+                        newProfileName = ""
+                        if let currentF0 = profileManager.currentProfile?.f0 {
+                            newProfileF0 = currentF0
+                        } else {
+                            newProfileF0 = 77.78
+                        }
+                        showingCreateProfileAlert = true
+                    } label: {
+                        Image(systemName: "plus.circle.fill")
+                    }
+                }
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    EditButton()
+                }
+            }
+            .sheet(item: $profileToEdit) { selectedProfile in
+                ProfileView(profileManager: profileManager, profile: selectedProfile)
+            }
+            .alert("New Profile", isPresented: $showingCreateProfileAlert, actions: {
+                TextField("Profile Name", text: $newProfileName)
+                TextField("f₀ (Hz)", value: $newProfileF0, formatter: hzFormatter)
+                    .keyboardType(.decimalPad)
+                Button("Create") {
+                    if !newProfileName.isEmpty {
+                        profileManager.addProfile(name: newProfileName, f0: newProfileF0)
+                    }
+                }
+                Button("Cancel", role: .cancel) { }
+            }, message: {
+                Text("Enter a name and fundamental frequency (f₀) for the new profile.")
+            })
+        }
+    }
+
+    private func deleteProfile(at offsets: IndexSet) {
+        profileManager.deleteProfile(at: offsets)
+    }
+
+    private var hzFormatter: NumberFormatter {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        formatter.maximumFractionDigits = 2
+        formatter.minimumFractionDigits = 2
+        return formatter
+    }
+}
+
+struct ProfilesTabView_Previews: PreviewProvider {
+    static var previews: some View {
+        ProfilesTabView()
+            .environmentObject(UserProfileManager())
+    }
+}

--- a/Chromatic/Views/TunerView.swift
+++ b/Chromatic/Views/TunerView.swift
@@ -9,7 +9,7 @@ struct TunerView: View {
     @State var selectedTransposition: Int
     
     @State private var showingToneSettings = false
-    @StateObject private var profileManager = UserProfileManager()
+    @EnvironmentObject private var profileManager: UserProfileManager
     @State private var userF0: Double = 77.78
     @State private var micMuted = false
     @State private var sessionStats: SessionStatistics?
@@ -316,6 +316,7 @@ struct TunerView_Previews: PreviewProvider {
             modifierPreference: .preferSharps,
             selectedTransposition: 0
         )
+        .environmentObject(UserProfileManager())
         .previewLayout(.device)
         .padding()
     }

--- a/ChromaticTests/TunerViewSnapshotTests.swift
+++ b/ChromaticTests/TunerViewSnapshotTests.swift
@@ -31,6 +31,7 @@ final class TunerViewSnapshotTests: XCTestCase {
                 modifierPreference: .preferSharps,
                 selectedTransposition: 0
             )
+            .environmentObject(UserProfileManager())
             for device in SnapshotDevice.all {
                 assertSnapshot(
                     matching: view,


### PR DESCRIPTION
## Summary
- make `UserProfileManager` a shared environment object
- expose profiles management in a new `ProfilesTabView`
- update `TunerView` to consume the environment profile manager
- update previews and snapshot tests for the environment object

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories)*
- `swift test` in `Packages/MicrophonePitchDetector` *(fails: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_686db8b569a88330895ae4c537617891