### PR TITLE
Enable editing f0 in profile view

### DIFF
--- a/Chromatic/Views/ProfileView.swift
+++ b/Chromatic/Views/ProfileView.swift
@@ -54,18 +54,21 @@ struct ProfileView: View {
                         TextField("Profile Name", text: $editingProfile.name)
                     }
                     let (f0Note, f0Cents) = noteNameAndCents(for: editingProfile.f0)
-                    Button(action: { tonePlayer.play(frequency: editingProfile.f0) }) {
+
+                    VStack(alignment: .leading, spacing: 4) {
                         HStack {
-                            Text("f₀ (Hz):")
+                            F0SelectorView(f0Hz: $editingProfile.f0)
                             Spacer()
-                            VStack(alignment: .trailing, spacing: 0) {
-                                Text("\(editingProfile.f0, specifier: "%.2f") Hz")
-                                Text("\(f0Note) (\(f0Cents >= 0 ? "+" : "")\(f0Cents)¢)")
-                                    .foregroundColor(.secondary)
-                                    .font(.footnote)
+                            Button(action: { tonePlayer.play(frequency: editingProfile.f0) }) {
+                                Image(systemName: "play.circle")
+                                    .foregroundColor(.accentColor)
                             }
-                            Image(systemName: "play.circle")
-                                .foregroundColor(.accentColor)
+                        }
+                        HStack {
+                            Spacer()
+                            Text("\(f0Note) (\(f0Cents >= 0 ? "+" : "")\(f0Cents)¢)")
+                                .foregroundColor(.secondary)
+                                .font(.footnote)
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
- allow f₀ editing in `ProfileView` using `F0SelectorView`
- show closest note information and keep play button

## Testing
- `swift test --enable-test-discovery` *(fails: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_686dbc802c8c8330a21267346d841090