### PR TITLE
Fix duplicate sheet in TunerView

### DIFF
--- a/Chromatic/Views/TunerView.swift
+++ b/Chromatic/Views/TunerView.swift
@@ -282,9 +282,6 @@ struct TunerView: View {
         .sheet(isPresented: $showingProfileSelector) {
             ProfileSelectionView(profileManager: profileManager, isPresented: $showingProfileSelector)
         }
-        .sheet(isPresented: $showingProfileSelector) {
-            ProfileSelectionView(profileManager: profileManager, isPresented: $showingProfileSelector)
-        }
         .onAppear {
             if let currentF0 = profileManager.currentProfile?.f0 {
                 userF0 = currentF0


### PR DESCRIPTION
## Summary
- remove duplicate `.sheet` call for profile selector

## Testing
- `swift test` *(fails: could not clone dependencies due to network restriction)*

------
https://chatgpt.com/codex/tasks/task_e_686dbc84f7ec83308498532bb3ee88d1