### PR TITLE
Enable f₀ editing in profiles

### DIFF
--- a/Chromatic/Views/ProfileView.swift
+++ b/Chromatic/Views/ProfileView.swift
@@ -54,18 +54,22 @@ struct ProfileView: View {
                         TextField("Profile Name", text: $editingProfile.name)
                     }
                     let (f0Note, f0Cents) = noteNameAndCents(for: editingProfile.f0)
-                    Button(action: { tonePlayer.play(frequency: editingProfile.f0) }) {
+
+                    VStack(alignment: .leading, spacing: 4) {
                         HStack {
                             Text("f₀ (Hz):")
+                            F0SelectorView(f0Hz: $editingProfile.f0)
                             Spacer()
-                            VStack(alignment: .trailing, spacing: 0) {
-                                Text("\(editingProfile.f0, specifier: "%.2f") Hz")
-                                Text("\(f0Note) (\(f0Cents >= 0 ? "+" : "")\(f0Cents)¢)")
-                                    .foregroundColor(.secondary)
-                                    .font(.footnote)
+                            Button(action: { tonePlayer.play(frequency: editingProfile.f0) }) {
+                                Image(systemName: "play.circle")
+                                    .foregroundColor(.accentColor)
                             }
-                            Image(systemName: "play.circle")
-                                .foregroundColor(.accentColor)
+                        }
+                        HStack {
+                            Spacer()
+                            Text("\(f0Note) (\(f0Cents >= 0 ? "+" : "")\(f0Cents)¢)")
+                                .foregroundColor(.secondary)
+                                .font(.footnote)
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
- show F0SelectorView in Profile Details so f₀ is editable
- keep play button and note information
- still track f₀ changes when deciding if Save should be enabled

## Testing
- `swift test --enable-test-discovery` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_686dbc802c8c8330a21267346d841090