### PR TITLE
Expose pitchFrequencies constant

### DIFF
--- a/Chromatic/Models/Pitch.swift
+++ b/Chromatic/Models/Pitch.swift
@@ -1,13 +1,20 @@
 import Foundation
 
-struct Pitch: Identifiable, Hashable {
+/// Representation of a musical pitch.
+///
+/// Marked `public` so that tests and previews outside the main target can
+/// construct and reference `Pitch` values.
+public struct Pitch: Identifiable, Hashable {
     let id = UUID()
     let name: String
     let frequency: Double
 }
 
 /// All equal-tempered pitches from C0 through D#8/Eb8.
-let pitchFrequencies: [Pitch] = [
+///
+/// Declared `public` so that previews and unit tests can reference the same
+/// canonical list of pitches instead of hard-coding their own copies.
+public let pitchFrequencies: [Pitch] = [
     Pitch(name: "C0",   frequency: 16.35),
     Pitch(name: "C#0/Db0", frequency: 17.32),
     Pitch(name: "D0",   frequency: 18.35),

--- a/Chromatic/Views/StatsModalView.swift
+++ b/Chromatic/Views/StatsModalView.swift
@@ -144,10 +144,11 @@ struct StatsModalView_Previews: PreviewProvider {
     }
 }
 
-// Ensure pitchFrequencies is available for the preview context if it's defined globally or accessible.
-// If it's part of a class or struct, it might need to be mocked or provided.
-// For simplicity, assuming it's accessible or this part of preview won't crash.
-// If `pitchFrequencies` is not globally available, you might need to define a sample one here:
+// The preview uses the global `pitchFrequencies` constant from `Pitch.swift`.
+// Because that constant is `public`, tests and other modules can import it
+// directly. If you prefer to provide custom data, inject an array of `Pitch`
+// instances instead. A sample stub is shown below if you need to override it
+// locally:
 //let pitchFrequencies: [(name: String, frequency: Double)] = [
 //    ("A2", 110.00), ("A#2/Bb2", 116.54), ("B2", 123.47),
 //    ("C3", 130.81), ("C#3/Db3", 138.59), ("D3", 146.83),

--- a/ChromaticTests/FunctionGeneratorEngineTests.swift
+++ b/ChromaticTests/FunctionGeneratorEngineTests.swift
@@ -1,21 +1,18 @@
 import XCTest
 @testable import Chromatic
 
-// Dummy pitch data for testing, mirroring what might be in the app
-// In a real scenario, you might share the actual pitchFrequencies or use a mock.
-// For simplicity here, we'll redefine a small subset.
+// Dummy pitch data for testing. The production app exposes a public
+// `pitchFrequencies` constant (see `Pitch.swift`), so tests may use that
+// directly or provide their own subset as done here.
 let testPitchFrequencies: [Pitch] = [
     Pitch(name: "C4", frequency: 261.63),
     Pitch(name: "A4", frequency: 440.00),
     Pitch(name: "B4", frequency: 493.88)
 ]
 
-// Make pitchFrequencies accessible for testing if it's not already global
-// or provide a way to inject it. For this test, we'll assume the Channel
-// class can be modified or uses a globally accessible pitchFrequencies constant
-// that we can shadow or replace for testing.
-// For now, let's assume the real `pitchFrequencies` is accessible.
-// If not, the `Channel` class would need modification for testability (e.g., dependency injection).
+// The real application exposes `pitchFrequencies` publicly, so tests can use it
+// directly. If you need to provide custom test data, inject it by replacing the
+// constant or by adding parameters to the classes under test.
 
 class FunctionGeneratorEngineTests: XCTestCase {
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
 # chromatic
+
+This project defines a global constant `pitchFrequencies` containing the
+equal-tempered tuning table.  Previews and unit tests rely on this constant to
+look up pitch information.  It is declared `public` in
+`Chromatic/Models/Pitch.swift` so external contexts can reference it directly or
+replace it with test data when needed.


### PR DESCRIPTION
## Summary
- make `Pitch` and `pitchFrequencies` public
- document how previews/tests rely on the constant
- clarify dependency in StatsModalView preview
- update test comments

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_686dc35b31e483308ca7c3ab7b613001